### PR TITLE
docker: explicitly install python package

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get dist-upgrade -y \
 	&& apt-get install -y --no-install-recommends \
 		locales python3-pip gawk wget git-core diffstat unzip texinfo gcc-multilib \
     build-essential chrpath libsdl1.2-dev util-linux coreutils parted libtool lzop cpio \
-    screen tmux vim-tiny \
+    screen tmux vim-tiny python \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
             /var/cache/debconf/* \


### PR DESCRIPTION
Several OE packages (e.g. mtools, ca-certificates) depend on python2.7
but this dependency is not reflected in the respective recipes. So even
though OE provides and builds python-native package, it is not used.
We won't bother to fix these old recipes. Let's install python in the docker
image instead.